### PR TITLE
Glyphs 3 compatibility

### DIFF
--- a/Metrics & Kerning/Copy Kerning Pairs.py
+++ b/Metrics & Kerning/Copy Kerning Pairs.py
@@ -351,7 +351,7 @@ class CopyKerningPairs( object ):
 	def CopyKerningPairsMain( self, sender ):
 		try:
 			fMaster = f.selectedFontMaster
-			kernDic = f.kerningDict()
+			kernDic = f.kerning
 			newKernDic = {}
 			for thisMaster in f.masters:
 				kernList = []


### PR DESCRIPTION
## Copy Kerning Pairs.py 
### CopyKerningMain method
method `font.kerningDict()` doesn't work in Glyphs3

my suggestion is to use `font.kerning`