### PR TITLE
fix error caused by variable font settings

### DIFF
--- a/Instance Slider.py
+++ b/Instance Slider.py
@@ -25,6 +25,9 @@ while len(av) < 6:
 
 insList = []
 for ins in f.instances:
+	if not ins.axes:
+		# instance is a variable font setting
+		continue
 	fn = ins.customParameters["familyName"] if ins.customParameters["familyName"] else f.familyName
 	insParameters = {
 		"Instance" : " ".join((fn, ins.name)),


### PR DESCRIPTION
Variable font settings are “instances” without axis values. The error is thrown when accessing int(ins.axes[i]).